### PR TITLE
Feature/default ports

### DIFF
--- a/src/lubiezurek/texasholdem/Program.java
+++ b/src/lubiezurek/texasholdem/Program.java
@@ -6,6 +6,7 @@ import lubiezurek.texasholdem.client.Client;
 import lubiezurek.texasholdem.server.Server;
 
 public class Program {
+	static final String DEFAULT_PORT = "7777";
 
 	public static void main(String[] args) {
 		try {
@@ -17,8 +18,9 @@ public class Program {
 			String typ = args[0];
 			if(typ.equals("-s") || typ.equals("--server")) {
 				if(args.length != 2) {
-					Logger.error("Invalid number of arguments");
-					return;
+					args = new String[2];
+					args[0] = "-s";
+					args[1] = DEFAULT_PORT; 
 				}
 				Server server = new Server(args);
 				server.run();

--- a/src/lubiezurek/texasholdem/Program.java
+++ b/src/lubiezurek/texasholdem/Program.java
@@ -33,13 +33,22 @@ public class Program {
 					default_args[2] = DEFAULT_PORT;
 					args = default_args;
 				}
+
 			}
 			
 			if(typ.equals("-s") || typ.equals("--server")) {
+				if(args.length != 2) {
+					Logger.error("Invalid number of arguments");
+					return;
+				}
 				Server server = new Server(args);
 				server.run();
 			}
 			else if(typ.equals("-c") || typ.equals("--client")) {
+				if(args.length != 3) {
+					Logger.error("Invalid number of arguments");
+					return;
+				}
 				Client client = new Client(args);
 				client.run();
 			}

--- a/src/lubiezurek/texasholdem/Program.java
+++ b/src/lubiezurek/texasholdem/Program.java
@@ -7,29 +7,39 @@ import lubiezurek.texasholdem.server.Server;
 
 public class Program {
 	static final String DEFAULT_PORT = "7777";
+	static final String DEFAULT_LOCALHOST = "127.0.0.1";
 
 	public static void main(String[] args) {
 		try {
-			if(args.length < 1) {
+			if(args.length == 0) {
 				Logger.error("Invalid number of arguments");
 				return;
 			}
 			
 			String typ = args[0];
-			if(typ.equals("-s") || typ.equals("--server")) {
-				if(args.length != 2) {
-					args = new String[2];
-					args[0] = "-s";
-					args[1] = DEFAULT_PORT; 
+
+			//Wstawianie domyślnych argumentów, jeśli brak innych
+			if(args.length == 1) {
+				if(typ.equals("-s") || typ.equals("--server")){
+					String[] default_args = new String[3];
+					default_args[0] = args[0];
+					default_args[1] = DEFAULT_PORT;
+					args = default_args;
 				}
+				else if(typ.equals("-c") || typ.equals("--client")){
+					String[] default_args = new String[3];
+					default_args[0] = args[0];
+					default_args[1] = DEFAULT_LOCALHOST;
+					default_args[2] = DEFAULT_PORT;
+					args = default_args;
+				}
+			}
+			
+			if(typ.equals("-s") || typ.equals("--server")) {
 				Server server = new Server(args);
 				server.run();
 			}
 			else if(typ.equals("-c") || typ.equals("--client")) {
-				if(args.length != 3) {
-					Logger.error("Invalid number of arguments");
-					return;
-				}
 				Client client = new Client(args);
 				client.run();
 			}


### PR DESCRIPTION
Dodałem obsługę domyślnych argumentów, tak dla wygody:

Dla wywołania z argumentem -c:
-c 127.0.0.1 7777

Dla wywołania z argumentem -s:
-s 7777

Dla każdej innej ilości argumentów, lub gdy args[0] ma jakiś inny, nieobsługiwany argument  args pozostaje bez zmian.
